### PR TITLE
[fix]: added list link and sub-heading in aside section - issue #20

### DIFF
--- a/docs/image.html
+++ b/docs/image.html
@@ -27,6 +27,9 @@
                 <a class="comp-link  my-xs" href="/docs/installation.html">Installation</a>
                 <a class="comp-link  my-xs" href="/docs/typography.html">Typography</a>
                 <hr>
+                <header>
+                    <h6 class="h6">Components</h6>
+                </header>
                 <a class="comp-link  my-xs" href="/docs/alert.html">Alert</a>
                 <a class="comp-link  my-xs" href="/docs/avatar.html">Avatar</a>
                 <a class="comp-link  my-xs" href="/docs/badge.html">Badge</a>
@@ -34,6 +37,7 @@
                 <a class="comp-link  my-xs" href="/docs/cards.html">Card</a>
                 <a class="active my-xs" href="/docs/image.html">Image</a>
                 <a class="comp-link  my-xs" href="/docs/input.html">Input</a>
+                <a class="comp-link  my-xs" href="/docs/list.html">List</a>
                 <a class="comp-link  my-xs" href="/docs/navbar.html">Navbar</a>
                 <a class="comp-link  my-xs" href="/docs/snackbar.html">Snackbar</a>
             </aside>

--- a/docs/input.html
+++ b/docs/input.html
@@ -27,6 +27,9 @@
                 <a class="comp-link  my-xs" href="/docs/installation.html">Installation</a>
                 <a class="comp-link  my-xs" href="/docs/typography.html">Typography</a>
                 <hr>
+                <header>
+                    <h6 class="h6">Components</h6>
+                </header>
                 <a class="comp-link  my-xs" href="/docs/alert.html">Alert</a>
                 <a class="comp-link  my-xs" href="/docs/avatar.html">Avatar</a>
                 <a class="comp-link  my-xs" href="/docs/badge.html">Badge</a>
@@ -34,6 +37,7 @@
                 <a class="comp-link  my-xs" href="/docs/cards.html">Card</a>
                 <a class="comp-link my-xs" href="/docs/image.html">Image</a>
                 <a class="active  my-xs" href="/docs/input.html">Input</a>
+                <a class="comp-link  my-xs" href="/docs/list.html">List</a>
                 <a class="comp-link  my-xs" href="/docs/navbar.html">Navbar</a>
                 <a class="comp-link  my-xs" href="/docs/snackbar.html">Snackbar</a>
             </aside>

--- a/docs/navbar.html
+++ b/docs/navbar.html
@@ -30,6 +30,9 @@
                 <a class="comp-link  my-xs" href="/docs/installation.html">Installation</a>
                 <a class="comp-link  my-xs" href="/docs/typography.html">Typography</a>
                 <hr>
+                <header>
+                    <h6 class="h6">Components</h6>
+                </header>
                 <a class="comp-link  my-xs" href="/docs/alert.html">Alert</a>
                 <a class="comp-link  my-xs" href="/docs/avatar.html">Avatar</a>
                 <a class="comp-link  my-xs" href="/docs/badge.html">Badge</a>
@@ -37,6 +40,7 @@
                 <a class="comp-link  my-xs" href="/docs/cards.html">Card</a>
                 <a class="comp-link my-xs" href="/docs/image.html">Image</a>
                 <a class="comp-link  my-xs" href="/docs/input.html">Input</a>
+                <a class="comp-link  my-xs" href="/docs/list.html">List</a>
                 <a class="active  my-xs" href="/docs/navbar.html">Navbar</a>
                 <a class="comp-link  my-xs" href="/docs/snackbar.html">Snackbar</a>
             </aside>

--- a/docs/snackbar.html
+++ b/docs/snackbar.html
@@ -27,6 +27,9 @@
                 <a class="comp-link  my-xs" href="/docs/installation.html">Installation</a>
                 <a class="comp-link  my-xs" href="/docs/typography.html">Typography</a>
                 <hr>
+                <header>
+                    <h6 class="h6">Components</h6>
+                </header>
                 <a class="comp-link  my-xs" href="/docs/alert.html">Alert</a>
                 <a class="comp-link  my-xs" href="/docs/avatar.html">Avatar</a>
                 <a class="comp-link  my-xs" href="/docs/badge.html">Badge</a>
@@ -34,6 +37,7 @@
                 <a class="comp-link  my-xs" href="/docs/cards.html">Card</a>
                 <a class="comp-link my-xs" href="/docs/image.html">Image</a>
                 <a class="comp-link  my-xs" href="/docs/input.html">Input</a>
+                <a class="comp-link  my-xs" href="/docs/list.html">List</a>
                 <a class="comp-link  my-xs" href="/docs/navbar.html">Navbar</a>
                 <a class="active  my-xs" href="/docs/snackbar.html">Snackbar</a>
             </aside>


### PR DESCRIPTION
Resolves issue #20 

List component documentation page was added later and thus, the component navigation panel did not have a link to it. 
Also, 'Component' sub-heading in component navigation panel was missing in some doc pages. This PR fixes both of these issues.