### PR TITLE
[fix]: added list link and sub-heading in aside section - issue #20

### DIFF
--- a/docs/alert.html
+++ b/docs/alert.html
@@ -37,6 +37,7 @@
                 <a class="comp-link  my-xs" href="/docs/cards.html">Card</a>
                 <a class="comp-link  my-xs" href="/docs/image.html">Image</a>
                 <a class="comp-link  my-xs" href="/docs/input.html">Input</a>
+                <a class="comp-link  my-xs" href="/docs/list.html">List</a>
                 <a class="comp-link  my-xs" href="/docs/navbar.html">Navbar</a>
                 <a class="comp-link  my-xs" href="/docs/snackbar.html">Snackbar</a>
             </aside>

--- a/docs/avatar.html
+++ b/docs/avatar.html
@@ -37,6 +37,7 @@
                 <a class="comp-link  my-xs" href="/docs/cards.html">Card</a>
                 <a class="comp-link  my-xs" href="/docs/image.html">Image</a>
                 <a class="comp-link  my-xs" href="/docs/input.html">Input</a>
+                <a class="comp-link  my-xs" href="/docs/list.html">List</a>
                 <a class="comp-link  my-xs" href="/docs/navbar.html">Navbar</a>
                 <a class="comp-link  my-xs" href="/docs/snackbar.html">Snackbar</a>
             </aside>

--- a/docs/badge.html
+++ b/docs/badge.html
@@ -40,6 +40,7 @@
                 <a class="comp-link  my-xs" href="/docs/cards.html">Card</a>
                 <a class="comp-link  my-xs" href="/docs/image.html">Image</a>
                 <a class="comp-link  my-xs" href="/docs/input.html">Input</a>
+                <a class="comp-link  my-xs" href="/docs/list.html">List</a>
                 <a class="comp-link  my-xs" href="/docs/navbar.html">Navbar</a>
                 <a class="comp-link  my-xs" href="/docs/snackbar.html">Snackbar</a>
             </aside>

--- a/docs/button.html
+++ b/docs/button.html
@@ -41,6 +41,7 @@
                 <a class="comp-link  my-xs" href="/docs/cards.html">Card</a>
                 <a class="comp-link  my-xs" href="/docs/image.html">Image</a>
                 <a class="comp-link  my-xs" href="/docs/input.html">Input</a>
+                <a class="comp-link  my-xs" href="/docs/list.html">List</a>
                 <a class="comp-link  my-xs" href="/docs/navbar.html">Navbar</a>
                 <a class="comp-link  my-xs" href="/docs/snackbar.html">Snackbar</a>
             </aside>

--- a/docs/cards.html
+++ b/docs/cards.html
@@ -40,6 +40,7 @@
                 <a class="active  my-xs" href="/docs/cards.html">Card</a>
                 <a class="comp-link  my-xs" href="/docs/image.html">Image</a>
                 <a class="comp-link  my-xs" href="/docs/input.html">Input</a>
+                <a class="comp-link  my-xs" href="/docs/list.html">List</a>
                 <a class="comp-link  my-xs" href="/docs/navbar.html">Navbar</a>
                 <a class="comp-link  my-xs" href="/docs/snackbar.html">Snackbar</a>
             </aside>


### PR DESCRIPTION
Resolves issue #20 

List component documentation page was added later and thus, the component navigation panel did not have a link to it.
Also, 'Component' sub-heading in component navigation panel was missing in some doc pages. This PR fixes both of these issues.